### PR TITLE
feat: localstorage 유틸 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,5 +128,8 @@
   "dependencies": {
     "amplitude-js": "^8.3.0",
     "firebase": "^8.6.3"
+  },
+  "peerDependencies": {
+    "date-fns": "^2.22.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,8 @@
 export { default as logger, FirebaseConfig } from './logger';
 export { default as delay } from './delay';
+export {
+  setLocalStorageItem,
+  getLocalStorageItem,
+  removeLocalStorageItem,
+  clearLocalStorage,
+} from './localStorage';

--- a/src/localStorage/index.ts
+++ b/src/localStorage/index.ts
@@ -37,12 +37,16 @@ function getExpiry(expiryHour?: number) {
   }
 }
 
+function printNoStorageWarningLog() {
+  console.warn('로컬스토리지를 사용할 수 없는 환경입니다');
+}
+
 /**
  * 로컬스토리지에 데이터를 저장합니다. 3번째 인자 expiryHour로 데이터의 만료 시간을 지정할 수 있습니다.
  */
 export function setLocalStorageItem<T>(key: string, data: T, expiryHour?: number) {
   if (!canUseStorage()) {
-    console.warn('로컬스토리지를 사용할 수 없는 환경입니다');
+    printNoStorageWarningLog();
     return;
   }
 
@@ -59,7 +63,7 @@ export function setLocalStorageItem<T>(key: string, data: T, expiryHour?: number
  */
 export function getLocalStorageItem<T>(key: string): T | null {
   if (!canUseStorage()) {
-    console.warn('로컬스토리지를 사용할 수 없는 환경입니다');
+    printNoStorageWarningLog();
     return null;
   }
 
@@ -77,4 +81,28 @@ export function getLocalStorageItem<T>(key: string): T | null {
     window.localStorage.removeItem(key);
     return null;
   }
+}
+
+/**
+ * 로컬스토리지에서 데이터를 제거합니다.
+ */
+export function removeLocalStorageItem(key: string) {
+  if (!canUseStorage()) {
+    printNoStorageWarningLog();
+    return;
+  }
+
+  window.localStorage.removeItem(key);
+}
+
+/**
+ * 로컬스토리지 내의 모든 데이터를 제거합니다.
+ */
+export function clearLocalStorage() {
+  if (!canUseStorage()) {
+    printNoStorageWarningLog();
+    return;
+  }
+
+  window.localStorage.clear();
 }

--- a/src/localStorage/index.ts
+++ b/src/localStorage/index.ts
@@ -96,6 +96,15 @@ export function removeLocalStorageItem(key: string) {
 }
 
 /**
+ * 로컬스토리지에서 데이터를 가져온 후 해당 데이터를 로컬스토리지에서 제거합니다.
+ */
+export function popLocalStorageItem<T>(key: string): T | null {
+  const data = getLocalStorageItem<T>(key);
+  removeLocalStorageItem(key);
+  return data;
+}
+
+/**
  * 로컬스토리지 내의 모든 데이터를 제거합니다.
  */
 export function clearLocalStorage() {

--- a/src/localStorage/index.ts
+++ b/src/localStorage/index.ts
@@ -1,0 +1,80 @@
+import formatISO from 'date-fns/formatISO';
+import addHours from 'date-fns/addHours';
+import isBefore from 'date-fns/isBefore';
+import { isServer } from '../constants/env';
+
+function canUseStorage() {
+  if (isServer === true) {
+    return false;
+  }
+
+  let storage;
+  try {
+    storage = window.localStorage;
+    const testItem = '__storage_test__';
+    storage.setItem(testItem, testItem);
+    storage.removeItem(testItem);
+    return true;
+  } catch (e) {
+    return (
+      e instanceof DOMException &&
+      (e.code === 22 ||
+        e.code === 1014 ||
+        e.name === 'QuotaExceededError' ||
+        e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
+      storage &&
+      storage.length > 0
+    );
+  }
+}
+
+function getExpiry(expiryHour?: number) {
+  const now = new Date();
+  if (expiryHour != null) {
+    return formatISO(addHours(now, expiryHour));
+  } else {
+    return '';
+  }
+}
+
+/**
+ * 로컬스토리지에 데이터를 저장합니다. 3번째 인자 expiryHour로 데이터의 만료 시간을 지정할 수 있습니다.
+ */
+export function setLocalStorageItem<T>(key: string, data: T, expiryHour?: number) {
+  if (!canUseStorage()) {
+    console.warn('로컬스토리지를 사용할 수 없는 환경입니다');
+    return;
+  }
+
+  const payload = {
+    data,
+    expiry: getExpiry(expiryHour),
+  };
+
+  window.localStorage.setItem(key, JSON.stringify(payload));
+}
+
+/**
+ * 로컬스토리지에서 데이터를 가져옵니다. 만약 만료 시간이 지정된 데이터이고, 만료 시간이 지난 상태라면 null이 반환됩니다.
+ */
+export function getLocalStorageItem<T>(key: string): T | null {
+  if (!canUseStorage()) {
+    console.warn('로컬스토리지를 사용할 수 없는 환경입니다');
+    return null;
+  }
+
+  const payload = window.localStorage.getItem(key);
+  if (payload == null) {
+    return null;
+  }
+
+  const parsedPayload: { data: T; expiry: string } = JSON.parse(payload);
+  const now = new Date();
+  const expiry = new Date(parsedPayload.expiry);
+  if (isNaN(expiry.getTime()) || isBefore(now, expiry)) {
+    return parsedPayload.data;
+  } else {
+    window.localStorage.removeItem(key);
+    return null;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2709,6 +2709,11 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
+date-fns@^2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
+  integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
+
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"


### PR DESCRIPTION
로컬스토리지와 관련된 유틸 함수들을 추가합니다.

## setLocalStorageItem
로컬스토리지에 데이터를 저장합니다. 데이터에는 만료일을 지정할 수 있으며, `{ value: T, expiryDate: string }`의 형태로 저장됩니다.

```ts
// 현재로부터 3시간 후 만료되는 user를 저장합니다
setLocalStorageItem('user', { name: 'Evan' }, 3);
```

## getLocalStorageItem
로컬스토리지에서 데이터를 가져옵니다. 해당 데이터는 함수 내에서 `JSON.parse`를 통해 파싱되므로 사용자가 명시적으로 파싱을 해줘야 할 필요가 없습니다.

만약 해당 데이터가 `setLocalStorageItem`을 통해 저장된 데이터가 아니라면 파싱한 데이터의 expiry를 검사하는 과정없이 그대로 반환합니다.

```ts
const user = getLocalStorageItem<{ name: string }>('user');
console.log(user);
// { name: 'Evan' }
```

## popLocalStorageItem
로컬스토리지에서 데이터를 꺼내온 후 해당 데이터를 로컬스토리지에서 제거합니다.

```ts
console.log(popLocalStorageItem('user'));
// { name: 'Evan' }
console.log(getLocalStorageItem('user'));
// null
```