### PR TITLE
fix: date-fns를 dependency로 이동

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,9 +127,7 @@
   },
   "dependencies": {
     "amplitude-js": "^8.3.0",
+    "date-fns": "^2.22.1",
     "firebase": "^8.6.3"
-  },
-  "peerDependencies": {
-    "date-fns": "^2.22.1"
   }
 }


### PR DESCRIPTION
CI 단계 컨테이너 내부에서 `date-fns`를 설치하지 못해 빌드 에러가 발생하고 있어서 일단 해당 패키지를 `dependencies`로 이동합니다.