### PR TITLE
Fix/delete 'sementic-release/git' on releaserc

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -20,12 +20,6 @@
     }],
     "@semantic-release/release-notes-generator",
     "@semantic-release/npm",
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json"]
-      }
-    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Description
github action에서 `sementic-release/git` 모듈을 찾지 못해 `main` 브랜치 빌드에 실패 하고 있음.

## Solved
현재 사용하고 있지 않은 모듈이라 제거 했을때 이슈 없음
- `sementic-release/git` 제거
