### PR TITLE
feat: 타입가드 관련 유틸 추가

### DIFF
--- a/src/commaizeNumber/index.ts
+++ b/src/commaizeNumber/index.ts
@@ -1,12 +1,16 @@
+import { isNumber } from '../is';
+
 const commaizeByRegex = (value: string) => value.replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,');
 
 /**
  * 인자로 주어진숫자의 3자리수 마다 콤마를 찍은 문자열을 반환합니다. ex)  1000000 -> 1,000,000
  */
-export function commaizeNumber(value: number | string) {
-  if (typeof value === 'number' && value.toLocaleString != null) {
+const commaizeNumber = (value: number | string) => {
+  if (isNumber(value) && value.toLocaleString != null) {
     return value.toLocaleString();
   }
 
   return commaizeByRegex(String(value));
-}
+};
+
+export default commaizeNumber;

--- a/src/getObjectKeys/index.ts
+++ b/src/getObjectKeys/index.ts
@@ -1,0 +1,8 @@
+/**
+ * 객체의 키가 아닌 string을 반환하는 Object.keys 대신 사용할 수 있는 Type Safe한 함수입니다
+ */
+function getObjectKeys<T extends Record<string, any>>(object: T) {
+  return Object.keys(object) as Array<keyof T>;
+}
+
+export default getObjectKeys;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,6 @@ export {
   removeLocalStorageItem,
   clearLocalStorage,
 } from './localStorage';
+export { default as commaizeNumber } from './commaizeNumber';
+export { default as getObjectKeys } from './getObjectKeys';
+export * from './is';

--- a/src/is/index.ts
+++ b/src/is/index.ts
@@ -20,24 +20,3 @@ export function isNumber(value: any): value is number {
 export function isBoolean(value: any): value is boolean {
   return typeof value === 'boolean';
 }
-
-interface Person {
-  name: string | number;
-}
-interface Evan extends Person {
-  name: string;
-}
-
-const person: Person = { name: 'evan' };
-
-if (is<Evan>(person, (v) => v.name === 'evan')) {
-  console.log(person); // Evan
-} else {
-  console.log(person); // Person
-}
-
-if (is<string>(person, (v) => typeof v.name === 'string')) {
-  // 뜬금없는 타입을 넣어버리면 인터섹션 타입으로 묶여버린다.
-  // 즉, 안전하지 않기 때문에 주의해서 사용해야 함.
-  console.log(person); // Person & string
-}

--- a/src/is/index.ts
+++ b/src/is/index.ts
@@ -1,3 +1,10 @@
+/**
+ * 타입가드를 편하게 사용할 수 있는 유틸 함수 입니다.
+ *
+ * 하지만 타입 가딩을 하는 타입이 string | number <=> string과 같은 서브타입 관계가 아니더라도, 이 함수는 그대로 타입가드를 적용하기 때문에 Type Safely하지 않은 상황이 발생할 수 있습니다.
+ *
+ * 이 함수를 사용하면 반드시 타입 가딩 이후에 타입이 어떻게 평가되었는지 확인해주세요.
+ */
 export function is<T>(value: any, validator: (v: any) => boolean): value is T {
   return validator(value);
 }
@@ -12,4 +19,25 @@ export function isNumber(value: any): value is number {
 
 export function isBoolean(value: any): value is boolean {
   return typeof value === 'boolean';
+}
+
+interface Person {
+  name: string | number;
+}
+interface Evan extends Person {
+  name: string;
+}
+
+const person: Person = { name: 'evan' };
+
+if (is<Evan>(person, (v) => v.name === 'evan')) {
+  console.log(person); // Evan
+} else {
+  console.log(person); // Person
+}
+
+if (is<string>(person, (v) => typeof v.name === 'string')) {
+  // 뜬금없는 타입을 넣어버리면 인터섹션 타입으로 묶여버린다.
+  // 즉, 안전하지 않기 때문에 주의해서 사용해야 함.
+  console.log(person); // Person & string
 }

--- a/src/is/index.ts
+++ b/src/is/index.ts
@@ -1,0 +1,15 @@
+export function is<T>(value: any, validator: (v: any) => boolean): value is T {
+  return validator(value);
+}
+
+export function isString(value: any): value is string {
+  return typeof value === 'string';
+}
+
+export function isNumber(value: any): value is number {
+  return typeof value === 'number';
+}
+
+export function isBoolean(value: any): value is boolean {
+  return typeof value === 'boolean';
+}


### PR DESCRIPTION
타입가드와 관련된 유틸을 추가합니다. 요 녀석들은 JS에서 사용해도 상관없기는 한데, JS에서 `getObjectKeys`는 `Object.keys`와 동작이 같아서 크게 의미가 없습니다.
요런 녀석들은 나중에 `@lubycon/typescript` 같은 걸로 떼어내도 좋을 것 같아요.

### getObjectKeys
객체의 키가 담긴 배열을 `string[]`로 밖에 평가하지 못하는 `Object.keys`를 Type Safely하게 사용할 수 있는 함수입니다.

```ts
const foo = { name: 'evan', age: 29 };

const keys = Object.keys(foo); // string[]
const typeSafelyKeys = getObjectKeys(foo) // ('name' | 'age')[];
```

### is

```ts
interface Props {
  id: string | number;
}

function Test ({ id }: Props) {
  const propsId = id; // string | number
  if (isString(id)) {
    // string
  } else if (isNumber(id)) {
    // number
  } else if (isBoolean(id) {
    // never
    // id의 타입이 string | number 였으므로 boolean 타입가드를 씌우면 타입이 성립할 수 없음
  } else if (is<string>(id, v => typeof v === 'string') {
    // string
  } else if (is<boolean>(id, v => typeof v === 'boolean') {
    // never
  }
}
```
```ts
interface Person {
  name: string;
}
interface Evan extends Person {
  name: 'evan';
}

const person: Person = { name: 'evan' };

if (is<Evan>(person, v => v.name === 'evan')) {
  console.log(person); // Evan
} else {
  console.log(person); // Person
}

if (is<string>(person, v => v.name === 'evan')) {
  // 뜬금없는 타입을 넣어버리면 인터섹션 타입으로 묶여버린다.
  // 즉, 안전하지 않기 때문에 주의해서 사용해야 함.
  console.log(person); // Person & string
}
```
